### PR TITLE
Remove reference to GITHUB_API_TOKEN

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,18 +5,11 @@ install_lein() {
     local version=$1
     local install_path=$2
 
-    local opts=""
-
-    if [ -n "$GITHUB_API_TOKEN" ]; then
-        opts="$opts --header 'Authorization: token $GITHUB_API_TOKEN'"
-    fi
-
     mkdir -p "$install_path/bin"
 
     curl --silent \
          --location \
          --output "$install_path/bin/lein" \
-         $opts \
          "https://codeberg.org/leiningen/leiningen/raw/tag/$version/bin/lein"
 
     chmod a+x "$install_path/bin/lein"


### PR DESCRIPTION
`mise install` was failing on my workstation rather mysteriously, but I finally figured out why.

1. My environment defined a `GITHUB_TOKEN` variable for accessing our enterprise Github instance.
2. Mise sees `GITHUB_TOKEN` and helpfully creates a copy of it called `GITHUB_API_TOKEN`.
3. The Leiningen install script sees the presence of `GITHUB_API_TOKEN` and uses it to populate the Authorization header.
4. The request to Codeberg fails because the Authorization header is present, but with a token that Codeberg does not recognize.
5. `curl` receives a 401 Bad Request response, so the `lein` script is not written to the expected location.
6. `chmod` fails because the expected file is not found.

The fix is to remove the `GITHUB_API_TOKEN` check, which is left over from the days when Leiningen was hosted on Github.